### PR TITLE
Only look in known good paths

### DIFF
--- a/SavingThrow.py
+++ b/SavingThrow.py
@@ -73,7 +73,7 @@ NEFARIOUS_FILE_SOURCES = []
 
 # Include Apple's identified Adware files by default.
 # https://support.apple.com/en-us/ht203987
-HT203987_URL = "https://raw.githubusercontent.com/SavingThrows/AdwareDefinitionFiles/master/Apple-HT203987.adf"  # pylint: disable=line-too-long
+HT203987_URL = "https://raw.githubusercontent.com/SavingThrows/AdwareDefinitionFiles/AdwareDefinitionFiles/master/Apple-HT203987.adf"  # pylint: disable=line-too-long
 NEFARIOUS_FILE_SOURCES.append(HT203987_URL)
 
 CACHE = "/Library/Application Support/SavingThrow"


### PR DESCRIPTION
References a proposed `known-good` folder of adf files

See also https://github.com/SavingThrows/AdwareDefinitionFiles/issues/11
